### PR TITLE
Allow subfield code "#"

### DIFF
--- a/src/HAB/Pica/Record/Subfield.php
+++ b/src/HAB/Pica/Record/Subfield.php
@@ -38,7 +38,7 @@ class Subfield
      *
      * @var string
      */
-    public static $validSubfieldCodePattern = '/^[a-z0-9]$/Di';
+    public static $validSubfieldCodePattern = '/^[a-z0-9#]$/Di';
 
     /**
      * Return true if argument is a valid subfield code.


### PR DESCRIPTION
In order to use your PicaRecord library we need this adaption, cause we're using "#" subfields in some cases.